### PR TITLE
Refactor and use built-in features.

### DIFF
--- a/_extrudes.scad
+++ b/_extrudes.scad
@@ -8,14 +8,9 @@ color("red") xz_extrude(my_points, my_extrude, false);
 color("blue") yz_extrude(my_points, my_extrude, false);
 */
 
-module xy_extrude(points, height, center = true){
-    if(center == true) 
-        translate ([0, 0, height/-2])  
-                linear_extrude(height) 
-                    polygon(points = points);
-   else
-        linear_extrude(height) 
-            polygon(points = points);
+module xy_extrude(points, height, center = true) {
+    linear_extrude(height = height, center = center) 
+        polygon(points = points); 
 };
 
 module xz_extrude(points, height, center = true){

--- a/_extrudes.scad
+++ b/_extrudes.scad
@@ -8,37 +8,37 @@ color("red") xz_extrude(my_points, my_extrude, false);
 color("blue") yz_extrude(my_points, my_extrude, false);
 */
 
-module xy_extrude(points , width , center = true){
+module xy_extrude(points, height, center = true){
     if(center == true) 
-        translate ([0, 0, width/-2])  
-                linear_extrude(width) 
+        translate ([0, 0, height/-2])  
+                linear_extrude(height) 
                     polygon(points = points);
    else
-        linear_extrude(width) 
+        linear_extrude(height) 
             polygon(points = points);
 };
 
-module xz_extrude(points , width , center = true){
+module xz_extrude(points, height, center = true){
     if(center == true) 
-        translate ([0, width/2, 0])        
+        translate ([0, height/2, 0])        
             rotate([90, 0, 0])
-                linear_extrude(width) 
+                linear_extrude(height) 
                     polygon(points = points);
    else
-       translate ([0, width, 0])    
+       translate ([0, height, 0])    
            rotate([90, 0, 0])
-               linear_extrude(width) 
+               linear_extrude(height) 
                    polygon(points = points);
 };
 
-module yz_extrude(points , width , center = true){
+module yz_extrude(points, height, center = true){
     if(center == true) 
-        translate ([width/-2, 0, 0])        
+        translate ([height/-2, 0, 0])        
             rotate([90, 0, 90])
-                linear_extrude(width) 
+                linear_extrude(height) 
                     polygon(points = points);
    else
         rotate([90, 0, 90])
-            linear_extrude(width) 
+            linear_extrude(height) 
                 polygon(points = points);
 };

--- a/_extrudes.scad
+++ b/_extrudes.scad
@@ -13,27 +13,13 @@ module xy_extrude(points, height, center = true) {
         polygon(points = points); 
 };
 
-module xz_extrude(points, height, center = true){
-    if(center == true) 
-        translate ([0, height/2, 0])        
-            rotate([90, 0, 0])
-                linear_extrude(height) 
-                    polygon(points = points);
-   else
-       translate ([0, height, 0])    
-           rotate([90, 0, 0])
-               linear_extrude(height) 
-                   polygon(points = points);
+module xz_extrude(points , height , center = true){
+    rotate([90, 0, 0])
+        mirror([0, 0, 1])        
+            xy_extrude(points, height, center);            
 };
 
-module yz_extrude(points, height, center = true){
-    if(center == true) 
-        translate ([height/-2, 0, 0])        
-            rotate([90, 0, 90])
-                linear_extrude(height) 
-                    polygon(points = points);
-   else
-        rotate([90, 0, 90])
-            linear_extrude(height) 
-                polygon(points = points);
+module yz_extrude(points , height , center = true){
+    rotate([90, 0, 90])
+        xy_extrude(points, height, center);
 };


### PR DESCRIPTION
1. use the same parameter `height` of `linear_extrude`.
2. use built-in `center` of `linear_extrude`.
3. `xz_extrude` and `yz_extrude` are based on `xy_extrude`.
