### PR TITLE
made original modules more generic

### DIFF
--- a/_extrudes.scad
+++ b/_extrudes.scad
@@ -3,23 +3,40 @@
 my_points = [[1, 2], [5, 2], [3, 8]];
 my_extrude = 3;
 
-color("yellow") xy_extrude(my_points, my_extrude, false);
-color("red") xz_extrude(my_points, my_extrude, false);
-color("blue") yz_extrude(my_points, my_extrude, false);
+color("yellow") xy_extrude_poly(my_points, my_extrude, false);
+color("red") xz_extrude_poly(my_points, my_extrude, false);
+color("blue") yz_extrude_poly(my_points, my_extrude, false);
 */
 
-module xy_extrude(points, height, center = true) {
-    linear_extrude(height = height, center = center) 
-        polygon(points = points); 
+module xy_extrude(height, center, convexity, twist, slices, scale) {
+	linear_extrude(height = height, center = center, convexity = convexity, twist = twist, slices = slices, scale = scale)
+	children();
 };
 
-module xz_extrude(points , height , center = true){
-    rotate([90, 0, 0])
-        mirror([0, 0, 1])        
-            xy_extrude(points, height, center);            
+module xz_extrude(height, center, convexity, twist, slices, scale) {
+	rotate([90, 0, 0])
+	mirror([0, 0, 1])
+	linear_extrude(height = height, center = center, convexity = convexity, twist = twist, slices = slices, scale = scale)
+	children();
 };
 
-module yz_extrude(points , height , center = true){
-    rotate([90, 0, 90])
-        xy_extrude(points, height, center);
+module yz_extrude(height, center, convexity, twist, slices, scale) {
+	rotate([90, 0, 90])
+	linear_extrude(height = height, center = center, convexity = convexity, twist = twist, slices = slices, scale = scale)
+	children();
+};
+
+module xy_extrude_poly(points, height, center = true) {
+	xy_extrude(height = height, center = center)
+		polygon(points = points); 
+};
+
+module xz_extrude_poly(points, height, center = true) {
+	xz_extrude(height = height, center = center)
+		polygon(points = points); 
+};
+
+module yz_extrude_poly(points, height, center = true) {
+	yz_extrude(height = height, center = center)
+		polygon(points = points); 
 };


### PR DESCRIPTION
This patch changes the original methods so that they use the `children()` to allow composition with other 2D shapes and more complex uses of `polygon()`, while also exposing the other formal parameters of the `linear_extrude()` function.

The original methods are still present, but renamed with a `_poly` suffix.
